### PR TITLE
Fix docs index links for GitHub Pages base

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -6,10 +6,10 @@ hero:
   tagline: AI-powered restaurant phone assistant built with LiveKit Agents
   actions:
     - text: Architecture Overview
-      link: /architecture/overview/
+      link: ./architecture/overview/
       icon: right-arrow
     - text: Development Guide
-      link: /guides/development/
+      link: ./guides/development/
       icon: external
       variant: minimal
 ---


### PR DESCRIPTION
## Summary
- use relative links on docs index hero buttons so they resolve under /panbot-docs/ base

## Testing
- npm run build