### PR TITLE
Align docs with Infisical, Logto status, multi-tenant auth

### DIFF
--- a/src/content/docs/guides/ci-cd.md
+++ b/src/content/docs/guides/ci-cd.md
@@ -123,6 +123,6 @@ Set in Infisical:
 
 ## Further Reading
 
-- [`README_ci_cd.md`](https://github.com/StellarChiron/panbot/blob/main/README_ci_cd.md) — Full CI/CD reference with Makefile details
+- `README_ci_cd.md` — Full CI/CD reference (available in the feature branch; if missing on main, use dev_docs below)
 - [`dev_docs/infisical_migration_guide.md`](https://github.com/StellarChiron/panbot/blob/main/dev_docs/infisical_migration_guide.md) — Infisical setup, troubleshooting, migration history
 - [`dev_docs/cloud_deployment_architecture.md`](https://github.com/StellarChiron/panbot/blob/main/dev_docs/cloud_deployment_architecture.md) — Resource sizing and scaling

--- a/src/content/docs/guides/development.md
+++ b/src/content/docs/guides/development.md
@@ -98,7 +98,21 @@ APIs and agents never access the database directly; they go through the services
 All data is scoped by `business_id`. JWT tokens carry claim-based authorization (no DB lookups per request). Restaurant detection on incoming calls uses SIP headers: `sip.h.diversion` in production (forwarded calls), `sip.h.to` in development.
 
 ### Environment System
-Tenant-based env files: `dev.env` (default), `prod.env`, `staging.env`. Pass `tenant=name` to make targets to use `{name}.env`. Desktop app has its own env files in `apps/desktop/`.
+
+:::tip[Infisical First]
+The **canonical** workflow is `make sync-env` (Infisical → `.env`) and centralized loading via `src/common/config.py:auto_load_environment_file()`.
+Legacy `dev.env` / `prod.env` files are still supported, but are **not** the primary path.
+:::
+
+`config.py` auto-load precedence (when `APP_NAME` + `ENVIRONMENT` are not already set):
+1. `{TENANT}.env` (if `TENANT` is set)
+2. `prod.env`
+3. `dev.env`
+4. `.env` (legacy fallback)
+
+Note: `make sync-env` produces `.env` for local use; production deploys typically set `APP_NAME` + `ENVIRONMENT` to skip auto-load.
+
+Desktop app has its own env files in `apps/desktop/`.
 
 ### Real-time Communication
 Centrifugo handles WebSocket push to connected clients. Namespace constants are auto-generated from `infrastructure/centrifugo/config.json` via `scripts/generate_centrifugo_namespaces.py`.

--- a/src/content/docs/guides/logto-auth.md
+++ b/src/content/docs/guides/logto-auth.md
@@ -3,6 +3,11 @@ title: Authentication with Logto
 description: How to set up Logto Cloud as PanBot's identity provider with social login (Google, Facebook, Microsoft, Apple).
 ---
 
+:::caution[🚧 Planned / Target State]
+Logto integration is **planned** (see Issue #30) and not fully implemented in the codebase yet. Use this guide as a target-state reference.
+Current production auth uses **fastapi-users JWT**.
+:::
+
 PanBot uses [Logto](https://logto.io) as its OIDC identity provider. This guide covers setting up Logto Cloud, configuring social login connectors, and connecting everything to the PanBot backend and web dashboard.
 
 ## Prerequisites

--- a/src/content/docs/guides/makefiles.md
+++ b/src/content/docs/guides/makefiles.md
@@ -7,7 +7,12 @@ Perfect! Your Makefile is ready to streamline your development and deployment wo
 
 ## 🌟 **Multi-Tenant Environment System**
 
-The Makefile uses a clean tenant-based environment system with `[tenant].env` files:
+:::tip[Infisical First]
+The **canonical** workflow is `make sync-env` (Infisical → `.env`) and centralized loading via `src/common/config.py:auto_load_environment_file()`.
+Legacy `dev.env` / `prod.env` files are still supported, but are **not** the primary path.
+:::
+
+The Makefile uses a tenant-based environment system with `[tenant].env` files:
 
 ```bash
 # Default development environment (uses dev.env)
@@ -38,11 +43,20 @@ panbot/
 
 ## 🚀 Quick Start
 
-### 1. **Set up your backend environment files:**
+### 1. **Sync secrets from Infisical (preferred):**
+```bash
+# Backend (dev) → .env
+make sync-env
+
+# Backend (prod) → .env
+make sync-env tenant=prod
+```
+
+### 2. **Legacy local env files (not recommended):**
 ```bash
 # Copy the example for each environment
 cp env.example dev.env       # Development (default)
-cp env.example prod.env      # Production  
+cp env.example prod.env      # Production
 cp env.example staging.env   # Staging (optional)
 
 # Edit each file with environment-specific credentials:

--- a/src/content/docs/reference/auth-system.md
+++ b/src/content/docs/reference/auth-system.md
@@ -16,6 +16,12 @@ description: Current and planned authentication architecture.
 | Token revocation | `users.token_version` field |
 | DB validation | Optional via `AUTH_VALIDATE_DB_ON_REQUEST` flag |
 
+### Current State: Hybrid Multi-Tenant Auth
+
+- JWTs are evolving toward a `business_ids` list for forward compatibility.
+- Database **still stores a single** `business_id` (UserBusinessDB migration is pending).
+- Expect mixed usage until Issue #29 is completed.
+
 ### Desktop App
 
 | Feature | Implementation |


### PR DESCRIPTION
## Summary
- add Infisical-first callouts + env precedence in development/makefiles
- mark Logto guide as planned/target state
- document hybrid multi-tenant auth in auth-system
- clarify README_ci_cd.md availability in CI/CD guide

## Testing
- docs changes only