### PR TITLE
ci(docs): run Auto Labeler on ubuntu-latest

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   label:
-    runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'enkira-ci-runner' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     permissions:
       issues: write
       pull-requests: write


### PR DESCRIPTION
Fixes CI queueing for docs PRs when self-hosted runner capacity is constrained.\n\nChange: force  to use  (workflow uses  only).\n\nContext: unblocks PR #14 (Issue #10) where the  check is stuck QUEUED due to  saturation.\n