### PR TITLE
docs: update site for new engineer onboarding

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,8 +2,8 @@ import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 
 export default defineConfig({
-	site: process.env.SITE_URL || 'https://stellarchiron.github.io',
-	base: process.env.BASE_PATH || '/panbot-docs/',
+	site: process.env.SITE_URL || 'https://docs.panbot.ai',
+	base: process.env.BASE_PATH || '/',
 	vite: {
 		server: {
 			allowedHosts: ['docs.panbot.ai'],

--- a/src/content/docs/architecture/data-flow.md
+++ b/src/content/docs/architecture/data-flow.md
@@ -27,20 +27,21 @@ Login form → POST /api/v1/auth/login → JWT (access + refresh)
     → Realtime token via POST /api/v1/realtime/token
 ```
 
-### Web Dashboard (Owner)
+### Desktop App (Device + PIN)
 ```
-OAuth button → NextAuth → Google/Microsoft/Apple
-    → JWT session (NextAuth)
-    → Backend token exchange (TODO: not yet wired)
-    → Business list via GET /api/v1/businesses/my
+Pairing code → POST /api/v1/auth/device/pair → device_token
+    → Staff enters PIN → POST /api/v1/auth/device/pin-login
+    → operator_session_token (8h JWT)
+    → Business context from device registration
 ```
 
-### Target State: Logto
+### Web Dashboard (Logto OIDC)
 ```
-OAuth → Logto SDK → OIDC tokens
-    → Backend validates OIDC token
-    → UserBusinessDB lookup → business list
-    → Per-business role (STAFF/OWNER/ADMIN)
+OAuth button → Logto SDK → Google/Microsoft/Apple
+    → Logto OIDC token
+    → POST /auth/oidc/callback → Backend JWT
+    → Business list via GET /api/v1/businesses/accessible
+    → Business selection → per-business context
 ```
 
 ## Real-time Event Flow
@@ -56,7 +57,7 @@ Backend service → HTTP API → Centrifugo server
 | `order.created` | Order service | Desktop (auto-print) |
 | `order.updated` | Order service | Desktop + Web |
 | `printer.status` | Printer service | Desktop |
-| `job.progress` | Temporal workflow | Web onboarding UI |
+| `job.progress` | Onboarding service | Web onboarding UI |
 
 ## Printer Data Flow
 

--- a/src/content/docs/architecture/multi-tenancy.md
+++ b/src/content/docs/architecture/multi-tenancy.md
@@ -7,24 +7,32 @@ description: How PanBot isolates data and operations per business.
 
 Every operational entity in PanBot is scoped by `business_id`. A single `businesses` table row represents one operational location.
 
-## Current State
+## Current State (Post Sprint 21)
 
 | Aspect | Implementation | Status |
 |--------|---------------|--------|
 | Data isolation | All queries filtered by `business_id` | Working |
-| JWT claims | `business_id`, `role`, `permissions` in token | Working |
+| JWT claims | `user_id`, `role`, `primary_business_id`, `permissions` | Working |
 | Phone routing | SIP headers → business lookup | Working |
-| User-business mapping | `UserDB.business_id` (single business) | Needs migration |
-| Role per business | Global role only | Needs migration |
+| User-business mapping | `UserBusinessDB` join table (many-to-many) | Working |
+| Role per business | `UserBusinessDB.role` per business | Working |
+| Business selection | Post-login business picker (web dashboard) | Working |
+| Auth | FastAPI-Users JWT + Logto OIDC (web) | Working |
 
-## Target State (Sprint 21)
+### UserBusinessDB
 
-| Aspect | Implementation | Status |
-|--------|---------------|--------|
-| User-business mapping | `UserBusinessDB` join table (one-to-many) | Planned (#29) |
-| Role per business | `UserBusinessDB.role` per business | Planned (#29) |
-| Business selection | Post-login business picker | Planned (#31) |
-| Logto IAM | Unified OAuth with social login | Planned (#30) |
+```python
+class UserBusinessDB(BaseDBModel, table=True):
+    user_id: uuid.UUID       # FK → users.id
+    business_id: uuid.UUID   # FK → businesses.id
+    role: UserRole           # Per-business role (STAFF/OWNER/ADMIN)
+    permissions: List[str]   # Per-business permissions (JSONB)
+    is_primary: bool         # For business selection UI
+```
+
+- `UserDB.business_id` has been **removed** — all business access resolved via `UserBusinessDB`
+- `require_business_access()` checks `UserBusinessDB` membership; owner/admin bypass
+- `GET /businesses/accessible` returns all businesses a user has access to
 
 ## Roles
 

--- a/src/content/docs/architecture/overview.md
+++ b/src/content/docs/architecture/overview.md
@@ -11,7 +11,7 @@ PanBot is an AI-powered restaurant phone assistant handling SIP calls via Telnyx
 |-----------|-----------|---------|
 | API Server | FastAPI (Python) | REST endpoints, auth, business logic |
 | Telephony Agent | LiveKit + Python | Voice AI for phone calls |
-| Web Dashboard | Next.js 16 + React 19 | Owner/admin management UI |
+| Web Dashboard | Next.js 15 + React 19 | Owner/admin management UI |
 | Desktop App | React 19 + Tauri 2 (Rust) | Restaurant staff operations + printing |
 | Real-time | Centrifugo v6 | WebSocket push notifications |
 | Database | PostgreSQL 15+ | Primary data store |
@@ -52,11 +52,11 @@ All data is scoped by `business_id`. JWT tokens carry claim-based authorization 
 
 | Aspect | Web Dashboard | Desktop App |
 |--------|--------------|-------------|
-| Framework | Next.js 16 + React 19 | Vite 7 + React 19 + Tauri 2 |
+| Framework | Next.js 15 + React 19 | Vite 7 + React 19 + Tauri 2 |
 | API Client | Custom fetch-based | Shared OpenAPI Axios client |
 | UI Components | shadcn/ui (Radix) | Custom component library |
-| Auth | NextAuth v5 (OAuth) | Direct JWT + localStorage |
-| Real-time | Not yet connected | Centrifugo WebSocket |
+| Auth | Logto SDK (OAuth/OIDC) | Direct JWT + localStorage + Device PIN |
+| Real-time | Centrifugo WebSocket (Sprint 21) | Centrifugo WebSocket |
 | Printing | N/A | Tauri Rust backend (ESC/POS + IPP) |
 
-See [apps/web/ARCHITECTURE.md](https://github.com/StellarChiron/panbot/blob/main/apps/web/ARCHITECTURE.md) and [apps/desktop/ARCHITECTURE.md](https://github.com/StellarChiron/panbot/blob/main/apps/desktop/ARCHITECTURE.md) for detailed frontend architecture.
+See [apps/web/ARCHITECTURE.md](https://github.com/enkira-ai/panbot/blob/dev/apps/web/ARCHITECTURE.md) and [apps/desktop/ARCHITECTURE.md](https://github.com/enkira-ai/panbot/blob/dev/apps/desktop/ARCHITECTURE.md) for detailed frontend architecture.

--- a/src/content/docs/guides/ci-cd.md
+++ b/src/content/docs/guides/ci-cd.md
@@ -123,6 +123,5 @@ Set in Infisical:
 
 ## Further Reading
 
-- `README_ci_cd.md` — Full CI/CD reference (available in the feature branch; if missing on main, use dev_docs below)
-- [`dev_docs/infisical_migration_guide.md`](https://github.com/StellarChiron/panbot/blob/main/dev_docs/infisical_migration_guide.md) — Infisical setup, troubleshooting, migration history
-- [`dev_docs/cloud_deployment_architecture.md`](https://github.com/StellarChiron/panbot/blob/main/dev_docs/cloud_deployment_architecture.md) — Resource sizing and scaling
+- [`project-docs/README_ci_cd.md`](https://github.com/enkira-ai/panbot/blob/dev/project-docs/README_ci_cd.md) — Full CI/CD reference
+- [`dev_docs/infisical_migration_guide.md`](https://github.com/enkira-ai/panbot/blob/dev/dev_docs/infisical_migration_guide.md) — Infisical setup, troubleshooting, migration history

--- a/src/content/docs/guides/development.md
+++ b/src/content/docs/guides/development.md
@@ -86,7 +86,7 @@ APIs and agents never access the database directly; they go through the services
 
 **`src/models/`** - `database.py` has SQLModel ORM models (table=True), `api.py` has Pydantic request/response models. Keep these separate.
 
-**`src/common/`** - Shared infrastructure: `config.py` (settings), `database.py` (DB connection), `cache.py` (Redis), `event_bus.py` (Kafka/MQTT events), `centrifugo.py` (WebSocket push).
+**`src/common/`** - Shared infrastructure: `config.py` (settings), `database.py` (DB connection), `cache.py` (Redis), `events.py` / `event_bus.py` (EventDB audit logging + Centrifugo real-time publishing), `centrifugo.py` (WebSocket push).
 
 **`src/workers/`** - Background workers. `scraper_worker.py` handles restaurant data scraping with Playwright.
 
@@ -142,6 +142,6 @@ await events.event_publisher.publish(event_type="order.created", ...)
 - **Langfuse**: LLM observability (via OpenTelemetry)
 
 ## Key Reference Docs
-- `architecture_design_doc.md` - Full system architecture and data models
+- `project-docs/architecture.md` - Full system architecture and data models
 - `sprints/` - Current sprint plans and tasks
 - `prompts/` - AI prompt templates and versions

--- a/src/content/docs/guides/logto-auth.md
+++ b/src/content/docs/guides/logto-auth.md
@@ -3,9 +3,14 @@ title: Authentication with Logto
 description: How to set up Logto Cloud as PanBot's identity provider with social login (Google, Facebook, Microsoft, Apple).
 ---
 
-:::caution[🚧 Planned / Target State]
-Logto integration is **planned** (see Issue #30) and not fully implemented in the codebase yet. Use this guide as a target-state reference.
-Current production auth uses **fastapi-users JWT**.
+:::note[Implementation Status]
+Logto OIDC is **partially implemented** as of Sprint 21:
+- **Backend**: `src/auth/oidc.py` with JWKS token validation, `/auth/oidc/callback` and `/auth/oidc/webhook` endpoints — **implemented** (PR #43)
+- **Web dashboard**: Logto SDK replaces NextAuth, business selection screen — **implemented** (panbot-web PR #3)
+- **Desktop app**: Still uses direct JWT login (Logto SDK migration is planned)
+- **Logto Cloud instance**: Needs to be deployed and configured (see setup steps below)
+
+Production auth remains **fastapi-users JWT** for the desktop app. The web dashboard uses Logto OIDC when a Logto instance is configured.
 :::
 
 PanBot uses [Logto](https://logto.io) as its OIDC identity provider. This guide covers setting up Logto Cloud, configuring social login connectors, and connecting everything to the PanBot backend and web dashboard.
@@ -100,7 +105,7 @@ For faster setup, use the provided automation script that configures everything 
    - Go to **Authorization** → **Roles** → Assign **"Logto Management API access"** role
    - Copy the **App ID** and **App Secret**
 
-3. **Get OAuth credentials** from each social provider you want to enable. See the [OAuth Credentials Guide](https://github.com/StellarChiron/panbot/blob/main/dev_docs/oauth_credentials_guide.md) for detailed steps:
+3. **Get OAuth credentials** from each social provider you want to enable. See the [OAuth Credentials Guide](https://github.com/enkira-ai/panbot/blob/main/dev_docs/oauth_credentials_guide.md) for detailed steps:
    - Google → Client ID + Client Secret
    - Facebook → App ID + App Secret
    - Microsoft → Client ID + Client Secret + Tenant ID

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -3,18 +3,29 @@ title: PanBot Documentation
 description: AI-powered restaurant phone assistant documentation.
 template: splash
 hero:
-  tagline: AI-powered restaurant phone assistant built with LiveKit Agents
+  tagline: AI-powered restaurant phone assistant built with LiveKit Agents, Deepgram STT, gpt-4.1-mini, and Cartesia TTS
   actions:
-    - text: Architecture Overview
-      link: ./architecture/overview/
+    - text: Getting Started
+      link: ./guides/environments/
       icon: right-arrow
-    - text: Development Guide
-      link: ./guides/development/
+    - text: Architecture
+      link: ./architecture/overview/
       icon: external
       variant: minimal
 ---
 
 import { Card, CardGrid } from '@astrojs/starlight/components';
+
+## New Here?
+
+If you're joining the team, start with these in order:
+
+1. **[System Overview](./architecture/overview/)** — Understand the components and how they connect (10 min)
+2. **[Environment Setup](./guides/environments/)** — Get your local dev environment running (30 min)
+3. **[Development Guide](./guides/development/)** — Commands, code patterns, and architecture rules (15 min)
+4. **[Telephony Agent](./guides/telephony-agent/)** — How the voice AI works (10 min)
+
+Also see `ONBOARDING.md` in the repo root for a quick-reference cheat sheet.
 
 ## Documentation Sections
 
@@ -23,16 +34,17 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 		System overview, data flows, multi-tenancy design, and integration plans.
 	</Card>
 	<Card title="Guides" icon="open-book">
-		Development setup, deployment, real-time integration, printer system, telephony agent, and testing.
+		Development setup, deployment, CI/CD, real-time integration, printer system, telephony agent, auth, and testing.
 	</Card>
 	<Card title="Reference" icon="document">
-		Architecture design document, authentication system, and API reference.
+		Architecture design document and authentication system reference.
 	</Card>
 </CardGrid>
 
 ## Quick Links
 
-- **For coding agents**: Start with `architecture.md` (root) and `src/*/ARCHITECTURE.md` files
-- **For humans**: Browse this documentation site
-- **Sprint planning**: See `sprints/` directory in the repo
-- **Research notes**: See `dev_docs/` directory in the repo
+- **Architecture deep dive**: `project-docs/architecture.md` in the repo (single source of truth)
+- **Per-component docs**: `src/*/ARCHITECTURE.md` files in the repo
+- **Sprint planning**: `sprints/` directory (current sprint docs)
+- **Research notes**: `dev_docs/` directory (active research and implementation guides)
+- **Historical docs**: `archive/` directory (completed sprints, early planning, outdated research)

--- a/src/content/docs/reference/auth-system.md
+++ b/src/content/docs/reference/auth-system.md
@@ -1,29 +1,41 @@
 ---
 title: Authentication System
-description: Current and planned authentication architecture.
+description: Current authentication architecture for PanBot.
 ---
 
-## Current State
+## Overview
 
-### Backend (FastAPI)
+PanBot uses a **hybrid auth system**: FastAPI-Users JWT for the backend core, Logto OIDC for the web dashboard, and device + PIN auth for the desktop app. All auth is claim-first (no DB lookups per request).
+
+## Backend (FastAPI)
 
 | Feature | Implementation |
 |---------|---------------|
 | Auth library | fastapi-users |
 | Token type | JWT (access + refresh) |
-| Claims | `user_id`, `business_id`, `role`, `permissions` |
+| Claims | `user_id`, `primary_business_id`, `role`, `permissions` |
 | Validation | Claim-first (no DB lookup per request) |
 | Token revocation | `users.token_version` field |
 | DB validation | Optional via `AUTH_VALIDATE_DB_ON_REQUEST` flag |
+| OIDC | Logto token validation via `src/auth/oidc.py` |
 
-### Multi-Tenant Auth (UserBusinessDB)
+### Auth Dependencies
 
-- `UserBusinessDB` is the source of truth for user-to-business mappings.
-- `UserDB.business_id` column has been **removed** — all business access is resolved via `UserBusinessDB`.
-- `get_current_user()` returns both `business_id` (primary) and `business_ids` (all accessible).
-- Realtime/Centrifugo token requests check against the full `business_ids` list.
+| Dependency | Behavior |
+|------------|----------|
+| `get_current_user()` | Wraps fastapi-users, returns `business_id` (primary) and `business_ids` (all accessible) |
+| `require_admin()` | Requires `is_superuser` or `business:admin` permission |
+| `require_business_access()` | Checks `UserBusinessDB` membership; owner/admin bypass |
+| `get_current_api_key()` | Validates `X-API-Key` header (prefix: `cfood_`) |
 
-### Desktop App (JWT Login)
+## Multi-Tenant Auth (UserBusinessDB)
+
+- `UserBusinessDB` is the source of truth for user-to-business mappings
+- `UserDB.business_id` column has been **removed** — all business access is resolved via `UserBusinessDB`
+- Roles are stored per-business in `UserBusinessDB.role` (STAFF/OWNER/ADMIN)
+- Realtime/Centrifugo token requests check against the full `business_ids` list
+
+## Desktop App (JWT Login)
 
 | Feature | Implementation |
 |---------|---------------|
@@ -33,7 +45,7 @@ description: Current and planned authentication architecture.
 | Business context | From JWT claims (`business_id`) |
 | Realtime token | Separate JWT via POST /api/v1/realtime/token |
 
-### Desktop App (Device + PIN Login)
+## Desktop App (Device + PIN Login)
 
 | Feature | Implementation |
 |---------|---------------|
@@ -45,35 +57,17 @@ description: Current and planned authentication architecture.
 
 See [Device Authentication guide](/guides/device-authentication/) for the complete flow.
 
-### Web Dashboard
+## Web Dashboard (Logto OIDC)
 
 | Feature | Implementation |
 |---------|---------------|
-| Auth library | NextAuth v5 beta |
-| Providers | Google, Microsoft Entra ID, Apple |
-| Strategy | JWT sessions (no DB sessions) |
-| Token exchange | Not yet wired to backend JWT |
+| Auth provider | Logto Cloud (OIDC) |
+| Frontend SDK | Logto React SDK (replaced NextAuth) |
+| Social login | Google, Microsoft, Apple via Logto |
+| Token exchange | `POST /auth/oidc/callback` exchanges Logto auth code for backend JWT |
+| Business selection | Post-login business picker from `GET /businesses/accessible` |
 
-## Target State: Logto Migration (Sprint 21 Phase 2)
-
-| Feature | Planned |
-|---------|---------|
-| IAM provider | Logto (replaces NextAuth + fastapi-users) |
-| Social login | Google, Apple via Logto |
-| Token format | OIDC tokens validated by backend |
-| Multi-business | UserBusinessDB with per-business roles |
-| Desktop | Logto SDK (replaces direct JWT login) |
-| Web | Logto SDK (replaces NextAuth) |
-
-### Migration Checklist
-
-- [ ] Set up Logto instance
-- [ ] Replace NextAuth with Logto SDK in web app
-- [ ] Update backend for OIDC token validation
-- [ ] Create UserBusinessDB sync endpoint
-- [ ] Handle Logto webhooks for user lifecycle
-- [ ] Migrate existing users
-- [ ] Update desktop app auth flow
+See [Logto Auth guide](/guides/logto-auth/) for setup details.
 
 ## JWT Token Configuration
 
@@ -81,8 +75,8 @@ All token lifetimes are configured in backend settings:
 
 | Setting | Purpose |
 |---------|---------|
-| `JWT_ACCESS_TOKEN_MINUTES` | Access token lifetime |
-| `JWT_REFRESH_TOKEN_DAYS` | Refresh token lifetime |
+| `JWT_ACCESS_TOKEN_MINUTES` | Access token lifetime (default: 30 min) |
+| `JWT_REFRESH_TOKEN_DAYS` | Refresh token lifetime (default: 30 days) |
 | `JWT_ALGORITHM` | Signing algorithm (HS256) |
 | `JWT_SECRET` | Token signing secret |
 
@@ -95,5 +89,3 @@ Desktop app fetches these settings from `/api/v1/realtime/status` for consistent
 | STAFF | PIN on paired device | Single business, desktop app |
 | OWNER | Email/OAuth or PIN | Multiple businesses, web + desktop |
 | ADMIN | Email/OAuth | All businesses, system settings |
-
-Roles are stored per-business in `UserBusinessDB.role`. Owners manage staff access and PIN assignment.


### PR DESCRIPTION
## Summary
- Add "New Here?" onboarding section to landing page with guided reading order
- Fix stale tech references: Next.js 16→15, Kafka/MQTT→EventDB+Centrifugo, StellarChiron→enkira-ai
- Update multi-tenancy docs to reflect Sprint 21 completion (UserBusinessDB is implemented, not planned)
- Update auth system docs with current hybrid state (JWT + Logto OIDC)
- Update Logto auth guide status: partially implemented (backend + web), not just planned
- Fix CI/CD links to `project-docs/README_ci_cd.md` (moved in parent repo)
- Update astro.config site URL from stellarchiron.github.io to docs.panbot.ai

## Context
A new head engineer is joining the team. This PR ensures the documentation site is accurate and navigable for onboarding.

## Test plan
- [ ] `npm run dev` builds without errors
- [ ] Landing page shows "New Here?" section
- [ ] All internal links resolve
- [ ] No stale tech references remain (Groq, Kafka, TiDB, StellarChiron)

🤖 Generated with [Claude Code](https://claude.com/claude-code)